### PR TITLE
Fix routing

### DIFF
--- a/golden-acorn/src/App.js
+++ b/golden-acorn/src/App.js
@@ -1,17 +1,24 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
 import './App.css';
-import App from './components/Home';
+import Home from './components/Home';
 import NavigationBar from './components/NavigationBar';
 import {
-	BrowserRouter as Router
+  BrowserRouter as Router, Route, Switch
 } from 'react-router-dom';
+import SimpleAcornApp from './components/SimpleAcornApp';
 
-ReactDOM.render(
-  <Router>
-      <NavigationBar />
-  </Router>,
-  document.getElementById("root")
-);
+const App = () => <Router>
+  <NavigationBar />
+  <Switch>
+    {/* If the current URL is /about, this route is rendered
+  while the rest are ignored */}
+    <Route exact path="/simple/states">
+      <SimpleAcornApp />
+    </Route>
+    <Route exact path="/">
+      <Home />
+    </Route>
+  </Switch>
+</Router>;
 
 export default App;

--- a/golden-acorn/src/components/NavigationBar.js
+++ b/golden-acorn/src/components/NavigationBar.js
@@ -2,39 +2,27 @@ import React from 'react';
 import SimpleAcornApp from './SimpleAcornApp';
 import Home from './Home';
 import {
-	BrowserRouter as Router,
-	Switch,
-	Route,
-	NavLink
+  BrowserRouter as Router,
+  Switch,
+  Route,
+  NavLink
 } from 'react-router-dom';
 
 export default function NavigationBar(props) {
-	return (
-		<div>
-			<Switch>
-				{/* If the current URL is /about, this route is rendered
-		while the rest are ignored */}
-				<Route exact path="/simple/states">
-					<SimpleAcornApp />
-				</Route>
-				<Route exact path="/">
-					<Home />
-				</Route>
-			</Switch>
-			<nav>
-				<ul>
-					<li>
-						<NavLink to="/" activeClassName="active">
-							Homepage
+  return (
+    <nav>
+      <ul>
+        <li>
+          <NavLink to="/" activeClassName="active">
+            Homepage
 						</NavLink>
-					</li>
-					<li>
-						<NavLink to="/simple/states" activeClassName="active">
-							With States
+        </li>
+        <li>
+          <NavLink to="/simple/states" activeClassName="active">
+            With States
 						</NavLink>
-					</li>
-				</ul>
-			</nav>
-		</div>
-	);
+        </li>
+      </ul>
+    </nav>
+  );
 }


### PR DESCRIPTION
I figured out what was wrong.

App.js had `ReactDOM.render()` inside. This was already present in `index.js` so it created some mess. `App.js` should just export a component.

App.js had `import App from './components/Home';` and then in the end `export default App`; so in the end it was exporting a different component instead of itself, bypassing all the routing.

Also, I moved the routing from Navigation Bar back to `<App />` where it should, navigation bar should be just a `<nav>`